### PR TITLE
Fix incorrect type in calls to ShapeHash

### DIFF
--- a/src/json-to-shape-hash.js
+++ b/src/json-to-shape-hash.js
@@ -4,22 +4,22 @@ function jsonToShapeHash(_data) {
   const jsTypeString = Object.prototype.toString.call(_data);
   if (jsTypeString === '[object Array]') {
     return ShapeHash(
-      PrimitiveTypes.ARRAY,
+      types.ARRAY,
       [],
       _data.map(item => jsonToShapeHash(item)));
   } else if (jsTypeString === '[object Object]') {
     return ShapeHash(
-      PrimitiveTypes.OBJECT,
+      types.OBJECT,
       Object.entries(_data).map(([key, value]) => ({key, hash: jsonToShapeHash(value)})),
       []);
   } else if (jsTypeString === '[object Number]') {
-    return ShapeHash(PrimitiveTypes.NUMBER);
+    return ShapeHash(types.NUMBER);
   } else if (jsTypeString === '[object String]') {
-    return ShapeHash(PrimitiveTypes.STRING);
+    return ShapeHash(types.STRING);
   } else if (jsTypeString === '[object Null]') {
-    return ShapeHash(PrimitiveTypes.NULL);
+    return ShapeHash(types.NULL);
   } else if (jsTypeString === '[object Boolean]') {
-    return ShapeHash(PrimitiveTypes.BOOLEAN);
+    return ShapeHash(types.BOOLEAN);
   } else {
     throw new Error('Unknown type! ' + jsTypeString);
   }
@@ -40,15 +40,6 @@ function bufferToHex(buffer) {
     .map(b => b.toString(16).padStart(2, '0'))
     .join('');
 }
-
-const PrimitiveTypes = {
-  OBJECT: 0,
-  ARRAY: 1,
-  STRING: 2,
-  NUMBER: 3,
-  BOOLEAN: 4,
-  NULL: 5
-};
 
 function ShapeHash(type, fields = [], items = [], rules = []) {
   return {type, fields, items, rules};


### PR DESCRIPTION
Shapehash encodings did not decode correctly because it used the wrong
lookup table when creating `ShapeHash` instances. We now use a correct
table, `json-to-shape-hash.js::types`.

```javascript
> a = {
      "firstname": "Aidan",
      "homestate": "PA"
    };
{ firstname: 'Aidan', homestate: 'PA' }

> hash = sh.toHash(a)
'0800120f0a0966697273746e616d6512020800120f0a09686f6d65737461746512020800'

> console.log(JSON.stringify(proto.decodeShapeHash(hash), null, 2))
{
  "type": "OBJECT",
  "fields": [
    {
      "key": "firstname",
      "hash": {
        "type": "OBJECT"
      }
    },
    {
      "key": "homestate",
      "hash": {
        "type": "OBJECT"
      }
    }
  ]
}
```

In this case, ["fields"]["*"]["hash"]["type"] should be "STRING".
Note that "OBJECT" happens to be the default for the field in
shapehash.proto.

Commit 4944b5d2ce081f7e4a9e86e7641c95c436e5ff31 pulled in external
protobuf files. These expect `ShapeDescriptor.type` to be a string
sourced from `json-to-shape-hash.js::types`. We accidentally used a copy
of `PrimitiveTypes` instead, prematurely converting the field into a
number. Subsequent encoding in `wire.js::_encodeShapeDescriptor` failed
lookups in `wire.js::encodePrimitiveTypes`, resulting in `undefined`
being used. This manifests as the default value of the field which,
unfortunately, is OBJECT, a valid value.

Signed-off-by: Ray Bejjani <ray.bejjani@useoptic.com>